### PR TITLE
Adding `Package.swift` for use in Swift projects

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "uk-railway-stations",
+    products: [
+        .library(
+            name: "uk-railway-stations",
+            targets: ["uk-railway-stations"]),
+    ],
+    targets: [
+        .target(
+            name: "uk-railway-stations", path: "./", resources: [.copy("./stations.json"), .copy("./stations.csv")],),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ import StationsListJSON from "uk-railway-stations"
 import StationsListCSV from "uk-railway-stations/stations.csv"
 ```
 
+### Swift Package Manager
+
+The dataset can also be pulled used Swift Package Manager. An extension on `Bundle` is provided to provide convinient access to both `stations.json`, and `stations.csv`. Add the following as a dependency in your `Package.swift`
+
+```
+dependencies: [.product(name: "uk-railway-stations", package: "uk-railway-stations")]
+```
+
 ## Attribution
 
 Attribution must be provided to myself, Trainline EU, and [their sources](https://github.com/trainline-eu/stations#licence) for this dataset.

--- a/uk-railway-stations.swift
+++ b/uk-railway-stations.swift
@@ -1,0 +1,17 @@
+//
+//  uk-railway-stations.swift
+//  uk-railway-stations
+//
+//  Created by Scotty on 11/06/2025.
+//
+
+import Foundation
+
+extension Bundle {
+    
+    /// URL for `stations.json` within the bundle
+    public static let stationsJSONBundleURL = Bundle.module.url(forResource: "stations", withExtension: "json")!
+    
+    /// URL for `stations.csv` within the bundle
+    public static let stationsCSVBundleURL = Bundle.module.url(forResource: "stations", withExtension: "csv")!
+}


### PR DESCRIPTION
Some Swift developers might find this handy in the future for their own little personal projects