### PR TITLE
feat: Add Newsham

### DIFF
--- a/stations.csv
+++ b/stations.csv
@@ -1681,6 +1681,7 @@ Newmarket,52.237904,0.406249,NMK,,england
 Newport (Essex),51.97995,0.216176,NWE,,england
 Newport (South Wales),51.590145,-2.998873,NWP,,wales
 Newquay,50.415245,-5.075769,NQY,,england
+Newsham,55.103279,-1.524313,NWH,,england
 Newstead,53.069961,-1.222036,NSD,,england
 Newton,55.819256,-4.133907,NTN,,scotland
 Newton Abbot,50.529507,-3.599957,NTA,,england


### PR DESCRIPTION
Adds Newsham station, which opened in March 2025: https://en.wikipedia.org/wiki/Newsham_railway_station

Lat/long is taken from RDG's "Knowledgebase Stations data feed" on raildata.org.uk, rounded to 6 decimal places:

```
  <CrsCode>NWH</CrsCode>
  <AlternativeIdentifiers>
    <NationalLocationCode>766800</NationalLocationCode>
  </AlternativeIdentifiers>
  <Name>Newsham</Name>
  <SixteenCharacterName>NEWSHAM</SixteenCharacterName>
  <Address>
    <com:PostalAddress>
      <add:A_5LineAddress>
        <add:Line>Newsham station</add:Line>
        <add:Line>Blagdon Drive</add:Line>
        <add:Line>Newsham</add:Line>
        <add:Line>Northumberland</add:Line>
        <add:PostCode>NE24 3QJ</add:PostCode>
      </add:A_5LineAddress>
    </com:PostalAddress>
  </Address>
  <Longitude>-1.5243134205643738</Longitude>
  <Latitude>55.10327921001849</Latitude>
```

https://www.google.com/maps/place/55°06'11.8"N+1°31'27.5"W/@55.103282,-1.5268879,873m

(Thanks very much for this dataset - I'm using it to drive the station search on https://stationlifts.org.uk/)
