### PR TITLE
feat: add Beaulieu Park station

### DIFF
--- a/stations.csv
+++ b/stations.csv
@@ -189,6 +189,7 @@ Bearley,52.244252,-1.750259,BER,,england
 Bearsden,55.917202,-4.332945,BRN,,scotland
 Bearsted,51.275589,0.57786,BSD,,england
 Beasdale,56.899624,-5.763864,BSL,,scotland
+Beaulieu Park,51.7574,0.5187,BPA,,england
 Beaulieu Road,50.854206,-1.505586,BEU,,england
 Beauly,57.478,-4.4698,BEL,,scotland
 Bebington,53.357651,-3.003659,BEB,,england


### PR DESCRIPTION
Adds the new Beaulieu Park station (opened on 26th October 2025).

Co-ords taken from the [wiki page](https://en.wikipedia.org/wiki/Beaulieu_Park_railway_station) which look to match up with where the station is located.